### PR TITLE
Remove duplicate new lines on Windows

### DIFF
--- a/src/lua/luadumper.cpp
+++ b/src/lua/luadumper.cpp
@@ -68,9 +68,9 @@ void glt::lua::IoThread() {
 					}
 
 					auto of = std::ofstream(path, glt::config::GetConfig().stealer_write_mode);
-					of << "-- " << sanitized_filename << "\n";
-					of << "-- Retrieved by https://github.com/lewisclark/glua-steal\n";
-					of << entry.code << "\n\n";
+					of << "-- " << sanitized_filename << std::endl;
+					of << "-- Retrieved by https://github.com/lewisclark/glua-steal" << std::endl;
+					of << entry.code;
 				}
 
 				shared_entries.clear();

--- a/src/lua/luadumper.cpp
+++ b/src/lua/luadumper.cpp
@@ -67,7 +67,7 @@ void glt::lua::IoThread() {
 						continue;
 					}
 
-					auto of = std::ofstream(path, glt::config::GetConfig().stealer_write_mode);
+					auto of = std::ofstream(path, glt::config::GetConfig().stealer_write_mode | std::ofstream::binary);
 					of << "-- " << sanitized_filename << std::endl;
 					of << "-- Retrieved by https://github.com/lewisclark/glua-steal" << std::endl;
 					of << entry.code;


### PR DESCRIPTION
Adds the binary write mode which stops Windows from converting new lines. 